### PR TITLE
fix: Update FaceClient http error handling logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ Build_BurstDebugInformation_DoNotShip/
 **/obj.meta
 Documentation/api/
 _site/
+*.zip

--- a/Assets/haechi.face.unity.sdk/Runtime/Client/Face/FaceLoginResponse.cs
+++ b/Assets/haechi.face.unity.sdk/Runtime/Client/Face/FaceLoginResponse.cs
@@ -62,5 +62,11 @@ namespace haechi.face.unity.sdk.Runtime.Client.Face
             [JsonProperty("keyId")]
             public string KeyId;
         }
+
+        public override string ToString()
+        {
+            return
+                $"faceUserId: {this.faceUserId}, wallet.id: {this.wallet.Id}, wallet.address: {this.wallet.Address}, wallet.signedAddress: {this.wallet.SignedAddress}";
+        }
     }
 }

--- a/Assets/haechi.face.unity.sdk/Runtime/Exception/RpcExceptioncs.cs
+++ b/Assets/haechi.face.unity.sdk/Runtime/Exception/RpcExceptioncs.cs
@@ -1,3 +1,6 @@
+using System.Net.Http;
+using Newtonsoft.Json;
+
 namespace haechi.face.unity.sdk.Runtime.Exception
 {
     public class InvalidWebviewMessageException : FaceException
@@ -29,4 +32,68 @@ namespace haechi.face.unity.sdk.Runtime.Exception
     {
         public WebviewClosedException() : base(ErrorCodes.WEBVIEW_CLOSED) {}
     }
+
+    public class FaceServerException : FaceException
+    {
+        public FaceServerException(FaceServerError error) : base(ErrorCodes.SERVER_RESPONSE_ERROR, error.ToString())
+        {
+        }
+    }
+    
+    /// <summary>
+    /// FaceServerError is a data for server error
+    /// </summary>
+    [JsonObject]
+    public class FaceServerError
+    {
+        /// <summary>
+        /// Timestamp for when the server handles the error
+        /// </summary>
+        [JsonProperty(PropertyName = "timestamp")]
+        public string Timestamp;
+        
+        /// <summary>
+        /// Path for the request
+        /// </summary>
+        [JsonProperty(PropertyName = "path")]
+        public string Path;
+        
+        /// <summary>
+        /// Error is a message for the cause of error
+        /// </summary>
+        [JsonProperty(PropertyName = "error")]
+        public string Error;
+        
+        /// <summary>
+        /// RequestId is a identifier for the request
+        /// </summary>
+        [JsonProperty(PropertyName = "requestId")]
+        public string RequestId;
+        
+        /// <summary>
+        /// Message is a message for the cause of error
+        /// </summary>
+        [JsonProperty(PropertyName = "message")]
+        public string Message;
+        
+        /// <summary>
+        /// Code about error cause
+        /// </summary>
+        [JsonProperty(PropertyName = "code")]
+        public string Code;
+        
+        /// <summary>
+        /// Status is a HTTP status code
+        /// </summary>
+        [JsonProperty(PropertyName = "status")]
+        public int Status;
+
+        public override string ToString()
+        {
+            return JsonConvert.SerializeObject(this, Formatting.None, 
+                new JsonSerializerSettings { 
+                    NullValueHandling = NullValueHandling.Ignore
+                });
+        }
+    } 
 }

--- a/Assets/haechi.face.unity.sdk/Runtime/Exception/RpcExceptioncs.cs
+++ b/Assets/haechi.face.unity.sdk/Runtime/Exception/RpcExceptioncs.cs
@@ -40,51 +40,51 @@ namespace haechi.face.unity.sdk.Runtime.Exception
         }
     }
     
-    /// <summary>
-    /// FaceServerError is a data for server error
-    /// </summary>
+    /// <value>
+    /// FaceServerError is a data for server error.
+    /// </value>
     [JsonObject]
     public class FaceServerError
     {
-        /// <summary>
-        /// Timestamp for when the server handles the error
-        /// </summary>
+        /// <value>
+        /// Timestamp for when the server handles the error.
+        /// </value>
         [JsonProperty(PropertyName = "timestamp")]
         public string Timestamp;
         
-        /// <summary>
-        /// Path for the request
-        /// </summary>
+        /// <value>
+        /// Path for the request.
+        /// </value>
         [JsonProperty(PropertyName = "path")]
         public string Path;
         
-        /// <summary>
-        /// Error is a message for the cause of error
-        /// </summary>
+        /// <value>
+        /// Error is a message for the cause of error.
+        /// </value>
         [JsonProperty(PropertyName = "error")]
         public string Error;
         
-        /// <summary>
-        /// RequestId is a identifier for the request
-        /// </summary>
+        /// <value>
+        /// RequestId is a identifier for the request.
+        /// </value>
         [JsonProperty(PropertyName = "requestId")]
         public string RequestId;
         
-        /// <summary>
-        /// Message is a message for the cause of error
-        /// </summary>
+        /// <value>
+        /// Message is a message for the cause of error.
+        /// </value>
         [JsonProperty(PropertyName = "message")]
         public string Message;
         
-        /// <summary>
-        /// Code about error cause
-        /// </summary>
+        /// <value>
+        /// Code about error cause.
+        /// </value>
         [JsonProperty(PropertyName = "code")]
         public string Code;
         
-        /// <summary>
-        /// Status is a HTTP status code
-        /// </summary>
+        /// <value>
+        /// Status is a HTTP status code.
+        /// </value>
         [JsonProperty(PropertyName = "status")]
         public int Status;
 

--- a/Assets/haechi.face.unity.sdk/Runtime/Face.cs
+++ b/Assets/haechi.face.unity.sdk/Runtime/Face.cs
@@ -12,7 +12,7 @@ namespace haechi.face.unity.sdk.Runtime
     public class Face : MonoBehaviour
     {
         
-        [SerializeField] internal SafeWebviewController safeWebviewController;
+        private SafeWebviewController _safeWebviewController;
 
         /// <value>
         /// This value indicates the version of webview client.
@@ -32,13 +32,13 @@ namespace haechi.face.unity.sdk.Runtime
         {
             FaceSettings.Init(parameters);
             
-            this.safeWebviewController = this.GetComponent<SafeWebviewController>();
+            this._safeWebviewController = this.GetComponent<SafeWebviewController>();
             
             this._walletProxy = new WalletProxy();
             this._authProxy = new AuthProxy();
             
             // Inject walletProxy instead of real Wallet. Because Wallet still not instantiated
-            FaceProviderFactory factory = new FaceProviderFactory(safeWebviewController, 
+            FaceProviderFactory factory = new FaceProviderFactory(this._safeWebviewController, 
                 FaceSettings.Instance.ServerHostURL(), this._walletProxy);
             this.provider = (FaceRpcProvider)factory.CreateUnityRpcClient();
             

--- a/Assets/haechi.face.unity.sdk/Runtime/FaceSettings.cs
+++ b/Assets/haechi.face.unity.sdk/Runtime/FaceSettings.cs
@@ -109,6 +109,11 @@ namespace haechi.face.unity.sdk.Runtime
         {
             return BlockchainNetworks.OfBlockchain(this._parameters._network);
         }
+
+        public BlockchainNetwork Network()
+        {
+            return this._parameters._network;
+        }
         
         private readonly Dictionary<Profile, string> _webviewHostMap = new Dictionary<Profile, string>
         {

--- a/Assets/haechi.face.unity.sdk/package.json
+++ b/Assets/haechi.face.unity.sdk/package.json
@@ -2,6 +2,8 @@
   "name": "haechi.face.unity.sdk",
   "version": "1.0.0",
   "displayName": "Face Unity SDK",
+  "description": "Face Unity SDK that helps integrating Face Wallet on the Unity platform",
+  "documentationUrl": "https://docs.facewallet.xyz/docs/overview-1",
   "unity": "2021.3",
   "dependencies": {
   }


### PR DESCRIPTION
- Update to show detailed HTTP error message
- Remove `[SerializeField]` attributes from SafeWebviewController on Face. Because SafeWebviewController is automatically attached via `[RequireComponent]` attributes and we don't need to inject SafeWebview on the inspector
- Update package.json