### PR TITLE
ci: Add CHANGELOG template, tagging GA pipeline

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,0 +1,26 @@
+{{ range .Versions }}
+<a name="{{ .Tag.Name }}"></a>
+## Release: [{{ .Tag.Name }}](https://github.com/HAECHI-LABS/core/releases/tag/{{ .Tag.Name }})
+{{ range .CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+
+{{- if .RevertCommits -}}
+### Reverts
+{{ range .RevertCommits -}}
+- {{ .Revert.Header }}
+{{ end }}
+{{ end -}}
+
+{{- if .NoteGroups -}}
+{{ range .NoteGroups -}}
+### {{ .Title }}
+{{ range .Notes }}
+{{ .Body }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -1,0 +1,40 @@
+style: github
+template: CHANGELOG.tpl.md
+info:
+  title: CHANGELOG
+  repository_url: https://github.com/HAECHI-LABS/core
+options:
+  commits:
+    filters:
+      Type:
+        - feat
+        - fix
+        - perf
+        - refactor
+        - ci
+        - docs
+  commit_groups:
+    # title_order defines which group would be show first on CHANGELOG
+    sort_by: "Custom"
+    title_order:
+      - feat
+      - fix
+      - perf
+      - refactor
+      - ci
+      - docs
+    title_maps:
+      feat: Features
+      fix: Bug Fixes
+      perf: Performance Improvements
+      refactor: Code Refactoring
+      ci: CI
+      docs: Document Updates
+  header:
+    pattern: "^(\\w*)\\:\\s(.*)$"
+    pattern_maps:
+      - Type
+      - Subject
+  notes:
+    keywords:
+      - BREAKING CHANGE

--- a/.github/workflows/tagging.yaml
+++ b/.github/workflows/tagging.yaml
@@ -1,0 +1,72 @@
+name: Tagging
+run-name: Tagging ${{ github.event.inputs.semver }}
+on:
+  workflow_dispatch:
+    inputs:
+      semver:
+        description: "Semantic version of release"
+        required: true
+jobs:
+  tagging:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Update package.json
+        env:
+          RELEASE_TAG: ${{ github.event.inputs.semver }}
+        run: |
+          tmp=$(mktemp)
+          jq '.version = "'${RELEASE_TAG}'"' Assets/haechi.face.unity.sdk/package.json > $tmp && mv $tmp Assets/haechi.face.unity.sdk/package.json
+      - name: Set up Golang
+        uses: actions/setup-go@v2.1.3
+        with:
+          go-version: 1.17
+      - name: Install
+        run: |
+          go get -u github.com/git-chglog/git-chglog/cmd/git-chglog
+      - name: Generate Change Log & Release Note
+        env:
+          RELEASE_TAG: ${{ github.event.inputs.semver }}
+        run: |
+          git tag ${RELEASE_TAG}
+          git-chglog ${RELEASE_TAG} > CHANGELOG.${RELEASE_TAG}.md
+          if [[ -f CHANGELOG.md ]]; then
+            cat CHANGELOG.md >> CHANGELOG.${RELEASE_TAG}.md
+          fi
+          mv CHANGELOG.${RELEASE_TAG}.md CHANGELOG.md
+          cp CHANGELOG.md Assets/haechi.face.unity.sdk/
+          git-chglog ${RELEASE_TAG} > RELEASE_NOTE.md
+          
+      - run: |
+          echo "Assets/haechi.face.unity.sdk.meta" > metaList
+          find Assets/haechi.face.unity.sdk/ -name \*.meta >> metaList
+      - run: mkdir build
+      - name: Build Unitypackage
+        uses: pCYSl5EDgo/create-unitypackage@master
+        with:
+          package-path: 'build/FaceUnitySDK.unitypackage'
+          include-files: metaList
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.HAECHI_GITHUB_PAT }}
+        with:
+          tag_name: ${{ github.event.inputs.semver }}
+          release_name: ${{ github.event.inputs.semver }}
+          draft: false
+          prerelease: false
+          body_path: ./RELEASE_NOTE.md
+          files: |
+            build/FaceUnitySDK.unitypackage
+      - name: Commit Change Log
+        run: |
+          git config --local user.email "haechi@github.com"
+          git config --local user.name "haechilabs"
+          git add CHANGELOG.md Assets/haechi.face.unity.sdk
+          git commit -m "chore: update CHANGELOG.md"
+      - name: Push Change Log
+        uses: ad-m/github-push-action@master
+        with:
+          branch: "releases/${{ github.event.inputs.semver }}"


### PR DESCRIPTION
- Add CHANGELOG template. It will be used on running `tagging` Github Action pipeline. In `tagging` pipeline, it creates a new release page with the CHANGELOG
- Added `tagging` pipeline. In the pipeline,
  - It updates the version field of `package.json` 
  - It creates Github Release and uploads a` .unitypackage file` on it
  - It updates `CHANGELOG.md`
  - It creates PR with the new `package.json` and `CHANGELOG.md`